### PR TITLE
🐛 [-bug] Fixed emergent regression on Linux when bootstrapping

### DIFF
--- a/src/BootstrapImpl.sh
+++ b/src/BootstrapImpl.sh
@@ -15,7 +15,7 @@
 set +e # Continue on errors
 
 echo ""
-echo "Script Version 0.12.1"
+echo "Script Version 0.12.2"
 echo ""
 
 # This script:
@@ -339,6 +339,8 @@ else
     # From this point forward, delete the environment if an error occurrs as the environment
     # won't be fully initialized.
 
+    export MAMBA_ROOT_PREFIX=~/micromamba
+
     # ----------------------------------------------------------------------
     # |  Initialize the shell
     if [[ ${error} == 0 ]]; then
@@ -374,6 +376,8 @@ else
 
     micromamba deactivate
     error=$?
+
+    unset MAMBA_ROOT_PREFIX
 
     if [[ ${error} != 0 ]]; then
         echo "[1ADeactivating the micromamba environment...[31m[1mFAILED[0m."

--- a/src/EndToEndTests/EndToEndTests.py
+++ b/src/EndToEndTests/EndToEndTests.py
@@ -53,7 +53,7 @@ if os.name.lower() == "nt":
     generate_set_command_func = lambda var, value: "set {}={}".format(var, value)
 
 else:
-    _script_version = "0.12.1"
+    _script_version = "0.12.2"
 
     _is_windows = False
 


### PR DESCRIPTION
An error associated with this fix just started happening. I thought it was related to a new version of micromamba, but I reverted to micromamba 1.5.8 and the problem was still happening. It is strange that it just suddenly appeared after working for so long.