### PR TITLE
👽️ [external_api_change] Ensure that micromamba.bat exists

### DIFF
--- a/.github/actions/build_and_test/action.yaml
+++ b/.github/actions/build_and_test/action.yaml
@@ -46,31 +46,31 @@ runs:
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.8
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.8
 
     - name: Bootstrap 3.9
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.9
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.9
 
     - name: Bootstrap 3.10
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.10
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.10
 
     - name: Bootstrap 3.11
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.11
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.11
 
     - name: Bootstrap 3.12
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.12
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.12
 
     - name: Black
       shell: ${{ inputs.shell_name }}

--- a/src/BootstrapImpl.cmd
+++ b/src/BootstrapImpl.cmd
@@ -14,7 +14,7 @@
 @setlocal EnableDelayedExpansion
 
 @echo.
-@echo Script Version 0.11.2
+@echo Script Version 0.11.2-BugBug1
 @echo.
 
 @REM This script:

--- a/src/BootstrapImpl.cmd
+++ b/src/BootstrapImpl.cmd
@@ -14,7 +14,7 @@
 @setlocal EnableDelayedExpansion
 
 @echo.
-@echo Script Version 0.11.1
+@echo Script Version 0.11.2
 @echo.
 
 @REM This script:
@@ -279,6 +279,12 @@ set _ERRORLEVEL=%ERRORLEVEL%
 
 if %_ERRORLEVEL% NEQ 0 goto :Exit
 
+@REM Ensure that micromamba.bat always exists (newer versions of micromamba only create mamba.bat).
+@REM This ensures that we are always backwards compatible.
+if not exist "%USERPROFILE%\micromamba\condabin\micromamba.bat" (
+    mklink "%USERPROFILE%\micromamba\condabin\micromamba.bat" "%USERPROFILE%\micromamba\condabin\mamba.bat"
+)
+
 echo.
 echo.
 echo.
@@ -509,7 +515,13 @@ for %%I in (%PYTHON_BOOTSTRAPPER_ACTIVATION_DIR%) do set _DIR_NAME=%%~nxI
     echo.
     echo pushd %cd%
     echo.
+    echo @REM Micromamba version 2.0.0 and 2.0.1 have a bug where activation will overwrite the path
+    echo @REM ^(see https://github.com/mamba-org/mamba/issues/3405^) for more info. Capture the
+    echo @REM current path and append it to the path after activation.
+    echo set _PREVIOUS_PATH=%%PATH%%
     echo call %USERPROFILE%\micromamba\condabin\micromamba.bat activate Python%PYTHON_BOOTSTRAPPER_ACTIVATION_VERSION%
+    echo set PATH=%%PATH%%;%%_PREVIOUS_PATH%%
+    echo.
     echo call %PYTHON_BOOTSTRAPPER_GENERATED_DIR%\Scripts\activate.bat
     echo.
     echo set PYTHON_BOOTSTRAPPER_ACTIVATION_DIR=%PYTHON_BOOTSTRAPPER_ACTIVATION_DIR%

--- a/src/BootstrapImpl.cmd
+++ b/src/BootstrapImpl.cmd
@@ -519,8 +519,24 @@ for %%I in (%PYTHON_BOOTSTRAPPER_ACTIVATION_DIR%) do set _DIR_NAME=%%~nxI
     echo @REM ^(see https://github.com/mamba-org/mamba/issues/3405^) for more info. Capture the
     echo @REM current path and append it to the path after activation.
     echo set _PREVIOUS_PATH=%%PATH%%
+    echo.
     echo call %USERPROFILE%\micromamba\condabin\micromamba.bat activate Python%PYTHON_BOOTSTRAPPER_ACTIVATION_VERSION%
-    echo set PATH=%%PATH%%;%%_PREVIOUS_PATH%%
+    echo.
+    echo setlocal enabledelayedexpansion
+    echo.
+    echo for %%%%i in (%%_PREVIOUS_PATH%%) do (
+    echo     set "found="
+    echo     for %%%%j in (!!PATH!!) do (
+    echo         if "%%%%i"=="%%%%j" (
+    echo             set "found=1"
+    echo             goto :exit_loop
+    echo         )
+    echo     )
+    echo     :exit_loop
+    echo     if not defined found (
+    echo         set "PATH=!!PATH!!;%%%%i"
+    echo     )
+    echo )
     echo.
     echo call %PYTHON_BOOTSTRAPPER_GENERATED_DIR%\Scripts\activate.bat
     echo.

--- a/src/BootstrapImpl.cmd
+++ b/src/BootstrapImpl.cmd
@@ -14,7 +14,7 @@
 @setlocal EnableDelayedExpansion
 
 @echo.
-@echo Script Version 0.11.2-BugBug1
+@echo Script Version 0.11.2
 @echo.
 
 @REM This script:

--- a/src/BootstrapImpl.cmd
+++ b/src/BootstrapImpl.cmd
@@ -518,25 +518,24 @@ for %%I in (%PYTHON_BOOTSTRAPPER_ACTIVATION_DIR%) do set _DIR_NAME=%%~nxI
     echo @REM Micromamba version 2.0.0 and 2.0.1 have a bug where activation will overwrite the path
     echo @REM ^(see https://github.com/mamba-org/mamba/issues/3405^) for more info. Capture the
     echo @REM current path and append it to the path after activation.
+    echo.
+    echo @REM Begin workaround
     echo set _PREVIOUS_PATH=%%PATH%%
     echo.
     echo call %USERPROFILE%\micromamba\condabin\micromamba.bat activate Python%PYTHON_BOOTSTRAPPER_ACTIVATION_VERSION%
     echo.
-    echo setlocal enabledelayedexpansion
+    echo setlocal EnableDelayedExpansion
     echo.
-    echo for %%%%i in (%%_PREVIOUS_PATH%%) do (
-    echo     set "found="
-    echo     for %%%%j in (!!PATH!!) do (
-    echo         if "%%%%i"=="%%%%j" (
-    echo             set "found=1"
-    echo             goto :exit_loop
-    echo         )
-    echo     )
-    echo     :exit_loop
-    echo     if not defined found (
-    echo         set "PATH=!!PATH!!;%%%%i"
-    echo     )
-    echo )
+    echo for %%%%a in ("%%_PREVIOUS_PATH:;=" "%%"^) do (
+    echo     echo ";%%PATH%%;" ^| find /C /I ";%%%%~a;" ^>NUL ^|^| (
+    echo         set "PATH=^!PATH^!;%%%%~a"
+    echo     ^)
+    echo ^)
+    echo.
+    echo endlocal
+    echo.
+    echo set _PREVIOUS_PATH=
+    echo @REM End workaround
     echo.
     echo call %PYTHON_BOOTSTRAPPER_GENERATED_DIR%\Scripts\activate.bat
     echo.

--- a/src/EndToEndTests/EndToEndTests.py
+++ b/src/EndToEndTests/EndToEndTests.py
@@ -38,7 +38,7 @@ PYTHON_VERSIONS = [
 
 # ----------------------------------------------------------------------
 if os.name.lower() == "nt":
-    _script_version = "0.11.1"
+    _script_version = "0.11.2"
 
     _is_windows = True
 
@@ -1796,7 +1796,7 @@ _error_result = _Execute([], Path(__file__).parent, INVALID_COMMAND)[0]
 def _GetBootstrapBranchArg() -> str:
     result = subprocess.run(
         "git branch --show-current",
-        check=True,
+        check=False,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/src/EndToEndTests/EndToEndTests.py
+++ b/src/EndToEndTests/EndToEndTests.py
@@ -1428,7 +1428,7 @@ class TestErrors(object):
             " && ".join(commands),
         )
 
-        assert result == 0
+        assert result == 0, output
         assert output == textwrap.dedent(
             f"""\
 


### PR DESCRIPTION
## :pencil: Description
Newer versions of micromamba create `mamba.bat` but not `micromamba.bat` as previous versions did. Ensure that `micromamba.bat` always exists so that the code is compatible with newer and older versions of micromamba.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A