### PR TITLE
👽️ [external_api_change] Ensure that micromamba.bat exists

### DIFF
--- a/.github/actions/build_and_test/action.yaml
+++ b/.github/actions/build_and_test/action.yaml
@@ -46,31 +46,31 @@ runs:
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.8
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.8
 
     - name: Bootstrap 3.9
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.9
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.9
 
     - name: Bootstrap 3.10
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.10
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.10
 
     - name: Bootstrap 3.11
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.11
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.11
 
     - name: Bootstrap 3.12
       shell: ${{ inputs.shell_name }}
       run: |
         cd src/EndToEndTests
-        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --python-version 3.12
+        ${{ inputs.script_prefix }}Bootstrap${{ inputs.script_extension }} --bootstrap-branch WindowsBug2 --python-version 3.12
 
     - name: Black
       shell: ${{ inputs.shell_name }}

--- a/src/EndToEndTests/EndToEndTests.py
+++ b/src/EndToEndTests/EndToEndTests.py
@@ -38,7 +38,7 @@ PYTHON_VERSIONS = [
 
 # ----------------------------------------------------------------------
 if os.name.lower() == "nt":
-    _script_version = "0.11.1"
+    _script_version = "0.11.2"
 
     _is_windows = True
 
@@ -1428,7 +1428,7 @@ class TestErrors(object):
             " && ".join(commands),
         )
 
-        assert result == 0
+        assert result == 0, output
         assert output == textwrap.dedent(
             f"""\
 
@@ -1796,7 +1796,7 @@ _error_result = _Execute([], Path(__file__).parent, INVALID_COMMAND)[0]
 def _GetBootstrapBranchArg() -> str:
     result = subprocess.run(
         "git branch --show-current",
-        check=True,
+        check=False,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## :pencil: Description
Newer versions of micromamba create `mamba.bat` but not `micromamba.bat` as previous versions did. Ensure that `micromamba.bat` always exists so that the code is compatible with newer and older versions of micromamba.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A